### PR TITLE
test: stop unit tests replacing the local crontab

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,25 @@
+# Copyright 2025 Canonical
+# See LICENSE file for licensing details.
+
+"""Shared fixtures for the unit tests."""
+
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def no_subprocess():
+    """Fail loudly if a test reaches a real subprocess call.
+
+    Unit tests must mock out the Langpacks methods that touch the machine
+    (for example, an unmocked setup_crontab would replace the crontab of
+    whoever runs the tests).
+    """
+    with patch(
+        "langpacks.run",
+        side_effect=AssertionError(
+            "unit test attempted to run a real subprocess; mock the Langpacks method"
+        ),
+    ):
+        yield

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical
+# Copyright 2026 Canonical
 # See LICENSE file for licensing details.
 
 """Shared fixtures for the unit tests."""

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -35,12 +35,14 @@ def base_state(ctx):
     return State(leader=True)
 
 
+@patch("charm.Langpacks.setup_crontab")
 @patch("charm.Langpacks.install")
-def test_install_success(install_mock, ctx, base_state):
+def test_install_success(install_mock, setup_crontab_mock, ctx, base_state):
     install_mock.return_value = True
     out = ctx.run(ctx.on.install(), base_state)
     assert out.unit_status == ActiveStatus("")
     assert install_mock.called
+    assert setup_crontab_mock.called
 
 
 @patch("charm.Langpacks.install")
@@ -60,12 +62,14 @@ def test_install_failure(mock, exception, ctx, base_state):
     )
 
 
+@patch("charm.Langpacks.setup_crontab")
 @patch("charm.Langpacks.install")
-def test_upgrade_success(install_mock, ctx, base_state):
+def test_upgrade_success(install_mock, setup_crontab_mock, ctx, base_state):
     install_mock.return_value = True
     out = ctx.run(ctx.on.upgrade_charm(), base_state)
     assert out.unit_status == ActiveStatus("")
     assert install_mock.called
+    assert setup_crontab_mock.called
 
 
 @patch("charm.Langpacks.install")


### PR DESCRIPTION
`test_install_success` and `test_upgrade_success` mock `Langpacks.install` but not `Langpacks.setup_crontab`, so the install handler pipes src/crontab into `crontab -`, replacing the real crontab of whoever runs the suite. Somewhat harmless in an ephemeral testing environment, but annoying data loss for anyone running unit tests locally.

This PR mocks `setup_crontab` in those tests, and for additional safety adds an autouse fixture that patches `langpacks.run` so any future unmocked subprocess call fails loudly instead of mutating the machine.